### PR TITLE
Fix checksum verification

### DIFF
--- a/aip-validator-api/src/main/java/de/bund/bsi/tresor/aip/validator/api/control/VerificationUtil.java
+++ b/aip-validator-api/src/main/java/de/bund/bsi/tresor/aip/validator/api/control/VerificationUtil.java
@@ -84,7 +84,7 @@ public class VerificationUtil
                         {
                             Streams.drain( digestIn );
                             byte[] digest = digestIn.getMessageDigest().digest();
-                            byte[] expectedDigest = Hex.decode( checksum.getCheckSum() );
+                            byte[] expectedDigest = checksum.getCheckSum();
                             
                             if ( org.bouncycastle.util.Arrays.constantTimeAreEqual( expectedDigest, digest ) )
                             {

--- a/aip-validator-api/src/test/java/de/bund/bsi/tresor/aip/validator/api/control/VerificationUtilTest.java
+++ b/aip-validator-api/src/test/java/de/bund/bsi/tresor/aip/validator/api/control/VerificationUtilTest.java
@@ -1,0 +1,103 @@
+/*-
+ * Copyright (c) 2020
+ * Federal Office for Information Security (BSI),
+ * Godesberger Allee 185-189,
+ * 53175 Bonn, Germany,
+ * phone: +49 228 99 9582-0,
+ * fax: +49 228 99 9582-5400,
+ * e-mail: bsi@bsi.bund.de
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.bund.bsi.tresor.aip.validator.api.control;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import javax.activation.DataHandler;
+import javax.activation.DataSource;
+import javax.activation.FileDataSource;
+
+import org.bouncycastle.util.encoders.Hex;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import de.bund.bsi.tr_esor.xaip._1.CheckSumType;
+import de.bund.bsi.tr_esor.xaip._1.DataObjectType;
+import de.bund.bsi.tr_esor.xaip._1.DataObjectType.BinaryData;
+import de.bund.bsi.tresor.aip.validator.api.entity.DefaultResult.Major;
+import de.bund.bsi.tresor.aip.validator.api.entity.DefaultResult.Minor;
+import de.bund.bsi.tresor.aip.validator.api.entity.aip.DigestAlgorithm;
+import oasis.names.tc.dss_x._1_0.profiles.verificationreport.schema_.VerificationResultType;
+
+/**
+ * @author tom-kuca
+ */
+public class VerificationUtilTest
+{
+    
+    @Test
+    @DisplayName( "should verify correct checksum" )
+    public void verifyChecksumSucessTest() throws IOException
+    {
+        DataSource dataSource = new FileDataSource( getClass().getResource( "/data.txt" ).getFile() );
+        DataHandler dataHandler = new DataHandler( dataSource );
+
+        BinaryData binaryData = new BinaryData();
+        binaryData.setValue( dataHandler );
+        
+        DataObjectType dataObject = new DataObjectType();
+		dataObject.setBinaryData( binaryData );
+
+    	CheckSumType checkSumType = new CheckSumType();
+    	checkSumType.setCheckSumAlgorithm( DigestAlgorithm.SHA256.getXmlUri() );
+
+    	byte[] checkSum = Hex.decode( "315f5bdb76d078c43b8ac0064e4a0164612b1fce77c869345bfc94c75894edd3".getBytes() );
+		checkSumType.setCheckSum( checkSum );
+
+        try ( InputStream is = getClass().getResourceAsStream( "/data.txt" ) ) {
+        	VerificationResultType result = VerificationUtil.verifyChecksum( is, checkSumType );
+            assertThat( result.getResultMajor(), is( equalTo( Major.VALID.getUri() ) ) );
+        }
+    }
+
+    @Test
+    @DisplayName( "should reject invalid checksum" )
+    public void verifyChecksumFailureTest() throws IOException
+    {
+        DataSource dataSource = new FileDataSource( getClass().getResource( "/data.txt" ).getFile() );
+        DataHandler dataHandler = new DataHandler( dataSource );
+
+        BinaryData binaryData = new BinaryData();
+        binaryData.setValue( dataHandler );
+        
+        DataObjectType dataObject = new DataObjectType();
+		dataObject.setBinaryData( binaryData );
+
+    	CheckSumType checkSumType = new CheckSumType();
+    	checkSumType.setCheckSumAlgorithm( DigestAlgorithm.SHA256.getXmlUri() );
+
+    	byte[] checkSum = Hex.decode( "0000000000000000000000000000000000000000000000000000000000000000".getBytes() );
+		checkSumType.setCheckSum( checkSum );
+
+        try ( InputStream is = getClass().getResourceAsStream( "/data.txt" ) ) {
+        	VerificationResultType result = VerificationUtil.verifyChecksum( is, checkSumType );
+            assertThat( result.getResultMajor(), is( equalTo( Major.INVALID.getUri() ) ) );
+            assertThat( result.getResultMinor(), is( equalTo( Minor.CHECKSUM_INVALID.getUri() ) ) );
+        }
+    }
+}

--- a/aip-validator-api/src/test/resources/data.txt
+++ b/aip-validator-api/src/test/resources/data.txt
@@ -1,0 +1,1 @@
+Hello, world!


### PR DESCRIPTION
I tried to use the syntax verification check of a xaip: 

```
java -jar aip-validator-cli/target/aip-validator-cli.jar -i sample.xaip -Mvalidator.schemaDir=./default-syntax-validator/src/main/resources/definitions --debug
```
with a XAIP

```xml
 <ns3:XAIP xmlns:ns10="urn:iso:std:iso-iec:24727:tech:schema" xmlns:ns11="http://www.xbarch.de" xmlns:ns2="urn:oasis:names:tc:dss:1.0:core:schema" xmlns:ns3="http://www.bsi.bund.de/tr-esor/xaip/1.2" xmlns:ns4="http://www.w3.org/2000/09/xmldsig#" xmlns:ns5="urn:oasis:names:tc:dss-x:1.0:profiles:verificationreport:schema#" xmlns:ns6="http://uri.etsi.org/01903/v1.3.2#" xmlns:ns7="http://www.bsi.bund.de/ecard/api/1.1" xmlns:ns8="http://www.setcce.org/schemas/ers" xmlns:ns9="http://www.bsi.bund.de/tr-esor/api/1.2" >
  <ns3:packageHeader packageID="x78fea42d-88c8-4559-9f75-2b6e873c2ac4">
    <ns3:AOID>2660725e-8eef-4645-986a-1a51af7e8265</ns3:AOID>
    <ns3:versionManifest VersionID="V001">
      <ns3:preservationInfo>
        <ns3:retentionPeriod>2100-01-01+01:00</ns3:retentionPeriod>
      </ns3:preservationInfo>
      <ns3:submissionInfo>
        <ns3:clientID>remotebean_esor12</ns3:clientID>
        <ns3:submissionTime>2017-02-10T15:07:42.821+01:00</ns3:submissionTime>
      </ns3:submissionInfo>
      <ns3:packageInfoUnit packageUnitID="_idx_DO-01_V001">
        <ns3:protectedObjectPointer>DO-01</ns3:protectedObjectPointer>
        <ns3:protectedObjectPointer>DO-02</ns3:protectedObjectPointer>
      </ns3:packageInfoUnit>
    </ns3:versionManifest>
    <ns4:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
  </ns3:packageHeader>
  <ns3:dataObjectsSection>
    <ns3:dataObject dataObjectID="DO-01">
      <ns3:binaryData>Y29udGVudCBvZiBkYXRhIG9iamVjdCBETy0wMQ==</ns3:binaryData>
      <ns3:checkSum>
        <ns3:checkSumAlgorithm>http://www.w3.org/2001/04/xmlenc#sha256</ns3:checkSumAlgorithm>
        <ns3:checkSum>eecc4d3352c0e965fd88795edfd1a60c5ac09b3c1100c052ebb6ae0bd3432b26</ns3:checkSum>
      </ns3:checkSum>
    </ns3:dataObject>
    <ns3:dataObject dataObjectID="DO-02">
      <ns3:binaryData>Y29udGVudCBvZiBkYXRhIG9iamVjdCBETy0wMg==</ns3:binaryData>
      <ns3:checkSum>
        <ns3:checkSumAlgorithm>http://www.w3.org/2001/04/xmlenc#sha256</ns3:checkSumAlgorithm>
        <ns3:checkSum>9ce2d7d350f9418407439f0ca11dcc12ab9f7cdb15f9ecc5eca935482602b872</ns3:checkSum>
      </ns3:checkSum>
    </ns3:dataObject>
  </ns3:dataObjectsSection>
</ns3:XAIP>    
```
For both checksums, there is a validation failure

```xml
<ns10:dataObject dataObjectID="DO-02">
  <ns10:checksum>
    <ns3:ResultMajor>http://www.bsi.bund.de/ecard/api/1.1/resultmajor#error</ns3:ResultMajor>
    <ns3:ResultMinor>http://www.bsi.bund.de/ecard/api/1.1/resultminor/arl/noDataAccessWarning</ns3:ResultMinor>
  </ns10:checksum>
</ns10:dataObject>
```

and a stack trace

```
[de.bund.bsi.tresor.aip.validator.dispatcher.Dispatcher] loaded SignatureFinder by BSI in version 1.0.0
[de.bund.bsi.tresor.aip.validator.dispatcher.Dispatcher] loaded SignatureVerifier by BSI in version 1.0.0
[de.bund.bsi.tresor.aip.validator.dispatcher.Dispatcher] loaded SyntaxValidator by BSI in version 1.0.0
[de.bund.bsi.tresor.aip.validator.dispatcher.Dispatcher] loaded ProtocolAssembler by BSI in version 1.0.0
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
[de.bund.bsi.tresor.aip.validator.syntax.validators.DataObjectSectionValidator] could not retrieve data for checksum validation
org.bouncycastle.util.encoders.DecoderException: exception decoding Hex data: Index -18 out of bounds for length 128
	at org.bouncycastle.util.encoders.Hex.decode(Unknown Source)
	at de.bund.bsi.tresor.aip.validator.api.control.VerificationUtil.lambda$verifyChecksum$0(VerificationUtil.java:87)
	at java.base/java.util.Optional.map(Optional.java:265)
	at de.bund.bsi.tresor.aip.validator.api.control.VerificationUtil.verifyChecksum(VerificationUtil.java:78)
	at de.bund.bsi.tresor.aip.validator.syntax.validators.DataObjectSectionValidator.lambda$validateDataObject$2(DataObjectSectionValidator.java:113)
	at java.base/java.util.Optional.map(Optional.java:265)
	at de.bund.bsi.tresor.aip.validator.syntax.validators.DataObjectSectionValidator.validateDataObject(DataObjectSectionValidator.java:108)
	at de.bund.bsi.tresor.aip.validator.syntax.validators.DataObjectSectionValidator.lambda$validateDataSection$0(DataObjectSectionValidator.java:78)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:195)
	at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1655)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474)
	at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:913)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:578)
	at de.bund.bsi.tresor.aip.validator.syntax.validators.DataObjectSectionValidator.lambda$validateDataSection$1(DataObjectSectionValidator.java:79)
	at java.base/java.util.Optional.map(Optional.java:265)
	at de.bund.bsi.tresor.aip.validator.syntax.validators.DataObjectSectionValidator.validateDataSection(DataObjectSectionValidator.java:77)
	at de.bund.bsi.tresor.aip.validator.syntax.DefaultSyntaxValidator.validateSyntax(DefaultSyntaxValidator.java:126)
	at de.bund.bsi.tresor.aip.validator.dispatcher.Dispatcher.dispatch(Dispatcher.java:94)
	at de.bund.bsi.tresor.aip.validator.cli.CLI.main(CLI.java:89)
Caused by: java.lang.ArrayIndexOutOfBoundsException: Index -18 out of bounds for length 128
	at org.bouncycastle.util.encoders.HexEncoder.decode(Unknown Source)
	... 21 more
[de.bund.bsi.tresor.aip.validator.syntax.validators.DataObjectSectionValidator] could not retrieve data for checksum validation
org.bouncycastle.util.encoders.DecoderException: exception decoding Hex data: Index -100 out of bounds for length 128
	at org.bouncycastle.util.encoders.Hex.decode(Unknown Source)
	at de.bund.bsi.tresor.aip.validator.api.control.VerificationUtil.lambda$verifyChecksum$0(VerificationUtil.java:87)
	at java.base/java.util.Optional.map(Optional.java:265)
	at de.bund.bsi.tresor.aip.validator.api.control.VerificationUtil.verifyChecksum(VerificationUtil.java:78)
	at de.bund.bsi.tresor.aip.validator.syntax.validators.DataObjectSectionValidator.lambda$validateDataObject$2(DataObjectSectionValidator.java:113)
	at java.base/java.util.Optional.map(Optional.java:265)
	at de.bund.bsi.tresor.aip.validator.syntax.validators.DataObjectSectionValidator.validateDataObject(DataObjectSectionValidator.java:108)
	at de.bund.bsi.tresor.aip.validator.syntax.validators.DataObjectSectionValidator.lambda$validateDataSection$0(DataObjectSectionValidator.java:78)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:195)
	at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1655)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474)
	at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:913)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:578)
	at de.bund.bsi.tresor.aip.validator.syntax.validators.DataObjectSectionValidator.lambda$validateDataSection$1(DataObjectSectionValidator.java:79)
	at java.base/java.util.Optional.map(Optional.java:265)
	at de.bund.bsi.tresor.aip.validator.syntax.validators.DataObjectSectionValidator.validateDataSection(DataObjectSectionValidator.java:77)
	at de.bund.bsi.tresor.aip.validator.syntax.DefaultSyntaxValidator.validateSyntax(DefaultSyntaxValidator.java:126)
	at de.bund.bsi.tresor.aip.validator.dispatcher.Dispatcher.dispatch(Dispatcher.java:94)
	at de.bund.bsi.tresor.aip.validator.cli.CLI.main(CLI.java:89)
Caused by: java.lang.ArrayIndexOutOfBoundsException: Index -100 out of bounds for length 128
	at org.bouncycastle.util.encoders.HexEncoder.decode(Unknown Source)
	... 21 more
[de.bund.bsi.tresor.aip.validator.dispatcher.Dispatcher] finished syntax validation
[de.bund.bsi.tresor.aip.validator.dispatcher.Dispatcher] finished protocol assembling
[de.bund.bsi.tresor.aip.validator.cli.CLI] finished validation
```

The checksum looks correct: 

    > echo Y29udGVudCBvZiBkYXRhIG9iamVjdCBETy0wMQ== | base64 -d | sha256sum
    eecc4d3352c0e965fd88795edfd1a60c5ac09b3c1100c052ebb6ae0bd3432b26 -

I checked the source and I realized that it tries to hex-decode already decoded byte array. BSI TR-ESOR-F doesn't mention that something special regarding the encoding, 

> This element includes the cryptographic checksum calculated using the algorithm
> mentioned above.

I believe that the XAIP should pass the validation check. The patch removes double decoding and adds a test for the checksum.